### PR TITLE
Add file tagging and cmp options

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,12 @@
 
 A tasteful LLM plugin.
 
+## Features
+
+- Chat with your models directly inside Neovim.
+- Use `@path/to/file` in a chat message to embed that file's contents as a fenced
+  code block before sending it to the model.
+- Optional nvim-cmp integration for convenient path completion in chat buffers
+  (`chat.enable_cmp = true`).
+
 WIP.


### PR DESCRIPTION
## Summary
- expand `@file/path` tags in chat messages and include contents as fenced code blocks
- optionally enable file path completion via nvim-cmp in chat buffers
- document new features in README

## Testing
- `luac` not available, unable to run Lua syntax checks

------
https://chatgpt.com/codex/tasks/task_e_68887ac6ab58832d98bb3d372f5fd9e9