### PR TITLE
Add configurable chat headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,19 @@
 A tasteful LLM plugin.
 
 WIP.
+
+## Configuration
+
+Chat headers are customizable via the `chat.headers` option:
+
+```lua
+require("delphi").setup({
+  chat = {
+    headers = {
+      system = "SYS>",
+      user = "ME>",
+      assistant = "BOT>",
+    },
+  },
+})
+```

--- a/lua/delphi/init.lua
+++ b/lua/delphi/init.lua
@@ -4,15 +4,20 @@ local P = require("delphi.primitives")
 ---@class Config
 ---@field models table<string, Model>
 ---@field allow_env_var_config boolean
----@field chat { system_prompt: string, default_model: string? }
+---@field chat { system_prompt: string, default_model: string?, headers: { system: string, user: string, assistant: string } }
 ---@field refactor { system_prompt: string, default_model: string?, prompt_template: string, accept_keymap: string, reject_keymap: string }
 local default_opts = {
 	models = {},
 	allow_env_var_config = false,
-	chat = {
-		system_prompt = "",
-		default_model = nil,
-	},
+        chat = {
+                system_prompt = "",
+                default_model = nil,
+                headers = {
+                        system = "System:",
+                        user = "User:",
+                        assistant = "Assistant:",
+                },
+        },
 	refactor = {
 		default_model = nil,
 		system_prompt = [[
@@ -66,9 +71,9 @@ local function setup_chat_cmd(config)
 			return vim.notify("The last message must be from the User!")
 		end
 
-		P.append_line_to_buf(buf, "")
-		P.append_line_to_buf(buf, "Assistant:")
-		P.append_line_to_buf(buf, "")
+                P.append_line_to_buf(buf, "")
+                P.append_line_to_buf(buf, P.headers.assistant)
+                P.append_line_to_buf(buf, "")
 
 		local default_model
 		if M.opts.allow_env_var_config and os.getenv("DELPHI_DEFAULT_CHAT_MODEL") then
@@ -87,9 +92,9 @@ local function setup_chat_cmd(config)
 		}, {
 			on_chunk = vim.schedule_wrap(function(chunk, is_done)
 				if is_done then
-					P.append_line_to_buf(buf, "")
-					P.append_line_to_buf(buf, "User: ")
-					P.append_line_to_buf(buf, "")
+                                        P.append_line_to_buf(buf, "")
+                                        P.append_line_to_buf(buf, P.headers.user .. " ")
+                                        P.append_line_to_buf(buf, "")
 					P.set_cursor_to_user(buf)
 					return
 				end
@@ -201,8 +206,9 @@ function M.setup(opts)
 	for k, v in pairs(models) do
 		models[k] = Model.new(v)
 	end
-	M.opts = vim.tbl_deep_extend("force", M.opts, opts or {})
-	setup_chat_cmd(M.opts.chat)
+        M.opts = vim.tbl_deep_extend("force", M.opts, opts or {})
+        P.set_headers(M.opts.chat.headers)
+        setup_chat_cmd(M.opts.chat)
 	setup_refactor_cmd(M.opts.refactor)
 end
 

--- a/lua/delphi/primitives.lua
+++ b/lua/delphi/primitives.lua
@@ -1,5 +1,25 @@
 local P = {}
 
+-- Header strings used in chat buffers
+P.headers = {
+        system = "System:",
+        user = "User:",
+        assistant = "Assistant:",
+}
+
+---Override the default chat headers
+---@param hdrs {system?:string,user?:string,assistant?:string}|nil
+function P.set_headers(hdrs)
+        if not hdrs then
+                return
+        end
+        for k, v in pairs(hdrs) do
+                if type(v) == "string" then
+                        P.headers[k] = v
+                end
+        end
+end
+
 ---Fill in a template string
 ---@param str string
 ---@param env table
@@ -26,15 +46,15 @@ local function strip(s)
 end
 
 local function get_header(line)
-	local hdr = nil
-	if starts_with(line, "System") then
-		hdr = "system"
-	elseif starts_with(line, "User") then
-		hdr = "user"
-	elseif starts_with(line, "Assistant") then
-		hdr = "assistant"
-	end
-	return hdr
+        local hdr = nil
+        if starts_with(line, P.headers.system) then
+                hdr = "system"
+        elseif starts_with(line, P.headers.user) then
+                hdr = "user"
+        elseif starts_with(line, P.headers.assistant) then
+                hdr = "assistant"
+        end
+        return hdr
 end
 
 function P.foldexpr(lnum)
@@ -112,14 +132,14 @@ end
 -- Move cursor to the last “User:” prompt in the given buffer
 ---@param buf integer
 function P.set_cursor_to_user(buf)
-	local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
-	for i = #lines, 1, -1 do
-		if lines[i]:match("^%s*User%s*:") then
-			for _, win in ipairs(vim.api.nvim_list_wins()) do
-				if vim.api.nvim_win_get_buf(win) == buf then
-					vim.api.nvim_set_current_win(win)
-					vim.api.nvim_win_set_cursor(win, { i + 1, 0 })
-					return
+        local lines = vim.api.nvim_buf_get_lines(buf, 0, -1, false)
+        for i = #lines, 1, -1 do
+                if lines[i]:match("^%s*" .. vim.pesc(P.headers.user)) then
+                        for _, win in ipairs(vim.api.nvim_list_wins()) do
+                                if vim.api.nvim_win_get_buf(win) == buf then
+                                        vim.api.nvim_set_current_win(win)
+                                        vim.api.nvim_win_set_cursor(win, { i + 1, 0 })
+                                        return
 				end
 			end
 		end
@@ -142,13 +162,13 @@ function P.open_new_chat_buffer(system_prompt)
 	-- vim.wo.foldmethod = "expr"
 	-- vim.wo.foldexpr = "v:lua.delphi_foldexpr(v:lnum)"
 
-	local lines = {
-		"System:",
-		system_prompt or "",
-		"", -- spacer
-		"User:",
-		"", -- where the user types
-	}
+        local lines = {
+                P.headers.system,
+                system_prompt or "",
+                "", -- spacer
+                P.headers.user,
+                "", -- where the user types
+        }
 	vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
 
 	P.set_cursor_to_user(buf) -- jump to User prompt


### PR DESCRIPTION
## Summary
- allow configuring header strings for chat logs
- document header config in README

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_688879b87208832db530f2d96a3b01a6