### PR TITLE
Fix code fence generation in prompts

### DIFF
--- a/lua/delphi/extractor.lua
+++ b/lua/delphi/extractor.lua
@@ -1,105 +1,73 @@
---- Grab markdown code block from streaming responses in O(n) time
---- with this state machine
+--- Grab fenced code from streaming responses with a simple state machine
 
-local function idle(code, c)
-	if c == "`" then
-		return code, "TICK_1"
-	end
-	return code, "IDLE"
-end
-
-local function tick_1(code, c)
-	if c == "`" then
-		return code, "TICK_2"
-	end
-	return code, "IDLE"
-end
-
-local function tick_2(code, c)
-	if c == "`" then
-		return code, "TICK_3"
-	end
-	return code, "IDLE"
-end
-
-local function tick_3(code, c)
-	-- allow arbitrary text after ``` until the next newline
-	if c == "\n" then
-		return code, "RECORDING"
-	end
-	return code, "TICK_3"
-end
-
-local function recording(code, c)
-	if c == "`" then
-		return code, "END_TICK_1"
-	end
-	return code .. c, "RECORDING"
-end
-
-local function end_tick_1(code, c)
-	if c == "`" then
-		return code, "END_TICK_2"
-	end
-	-- not actually a code fence, flush the pending tick
-	return code .. "`" .. c, "RECORDING"
-end
-
-local function end_tick_2(code, c)
-	if c == "`" then
-		return code, "DONE"
-	end
-	-- not actually a code fence, flush the pending ticks
-	return code .. "``" .. c, "RECORDING"
-end
-
-local function end_tick_3(code, c)
-	if c == "`" then
-		return code, "DONE"
-	end
-	return code .. c, "RECORDING"
-end
-
-local function done(code, _)
-	return code, "DONE"
-end
-
-local state_to_fn = {
-	IDLE = idle,
-	TICK_1 = tick_1,
-	TICK_2 = tick_2,
-	TICK_3 = tick_3,
-	RECORDING = recording,
-	END_TICK_1 = end_tick_1,
-	END_TICK_2 = end_tick_2,
-	END_TICK_3 = end_tick_3,
-	DONE = done,
-}
-
+---@class Extractor
+---@field fence_len integer
+---@field state 'WAIT_START' | 'SKIP_INFO' | 'RECORDING' | 'END' | 'DONE'
+---@field ticks integer
+---@field code string
 local Extractor = {}
 Extractor.__index = Extractor
 
-function Extractor.new()
-	return setmetatable({ state = "IDLE", code = "" }, Extractor)
+---Create a new Extractor
+---@param fence_len integer
+---@return Extractor
+function Extractor.new(fence_len)
+	fence_len = fence_len or 3
+	return setmetatable({ state = "WAIT_START", ticks = 0, fence_len = fence_len, code = "" }, Extractor)
 end
 
+---Update the extractor with streamed text
+---@param delta string
+---@return string new_code
 function Extractor:update(delta)
 	local new_code = ""
 	for i = 1, #delta do
+		local c = delta:sub(i, i)
 		if self.state == "DONE" then
 			break
+		elseif self.state == "WAIT_START" then
+			if c == "`" then
+				self.ticks = self.ticks + 1
+				if self.ticks == self.fence_len then
+					self.state = "SKIP_INFO"
+					self.ticks = 0
+				end
+			else
+				self.ticks = 0
+			end
+		elseif self.state == "SKIP_INFO" then
+			if c == "\n" then
+				self.state = "RECORDING"
+			end
+		elseif self.state == "RECORDING" then
+			if c == "`" then
+				self.ticks = 1
+				self.state = "END"
+			else
+				new_code = new_code .. c
+			end
+		elseif self.state == "END" then
+			if c == "`" then
+				self.ticks = self.ticks + 1
+				if self.ticks == self.fence_len then
+					self.state = "DONE"
+				end
+			else
+				new_code = new_code .. string.rep("`", self.ticks) .. c
+				self.ticks = 0
+				self.state = "RECORDING"
+			end
 		end
-		new_code, self.state = state_to_fn[self.state](new_code, delta:sub(i, i))
 	end
 	self.code = self.code .. new_code
 	return new_code
 end
 
+---Return all accumulated code (flushes unfinished fences)
+---@return string
 function Extractor:get_code()
-	if self.state == "END_TICK_1" then
-		return self.code .. "`"
-	elseif self.state == "END_TICK_2" then
-		return self.code .. "``"
+	if self.state == "END" then
+		return self.code .. string.rep("`", self.ticks)
 	end
 	return self.code
 end

--- a/lua/delphi/primitives.lua
+++ b/lua/delphi/primitives.lua
@@ -37,6 +37,35 @@ function P.template(str, env)
 	)
 end
 
+---Create a fenced Markdown code block with the minimal fence length
+---@param content string
+---@param info string?
+---@return string
+function P.fenced_block(content, info)
+	local max = 0
+	for ticks in content:gmatch("`+") do
+		if #ticks > max then
+			max = #ticks
+		end
+	end
+	local fence = string.rep("`", max + 1)
+	local header = info and (#info > 0) and (fence .. info) or fence
+	return string.format("%s\n%s\n%s", header, content, fence)
+end
+
+---Return the maximum number of consecutive backticks in `str`
+---@param str string
+---@return integer
+function P.max_backticks(str)
+	local max = 0
+	for ticks in str:gmatch("`+") do
+		if #ticks > max then
+			max = #ticks
+		end
+	end
+	return max
+end
+
 local function starts_with(str, prefix)
 	return str:sub(1, #prefix) == prefix
 end
@@ -483,7 +512,8 @@ function P.resolve_tags(meta, messages)
 			table.insert(prompt_lines, "<tagged_files>")
 			for _, t in ipairs(tags_in_msg) do
 				local ext = t.path:match("%.([%w_]+)$") or ""
-				table.insert(prompt_lines, string.format("```%s %s\n%s\n```", ext, t.path, t.content))
+				local info = ext ~= "" and (ext .. " " .. t.path) or t.path
+				table.insert(prompt_lines, P.fenced_block(t.content, info))
 			end
 			table.insert(prompt_lines, "</tagged_files>")
 			table.insert(prompt_lines, msg.content)


### PR DESCRIPTION
## Summary
- add helper to calculate backtick count
- instruct LLM to use exact fence length
- compute fence length for extractor and template
- make extractor handle variable fences

## Testing
- `nix develop -c stylua lua/delphi/primitives.lua lua/delphi/init.lua lua/delphi/extractor.lua`
- `nix develop -c bash -lc 'XDG_CONFIG_HOME=$NVIM_TEST_HOME nvim --clean -u "$NVIM_TEST_HOME/init.lua" --headless +"luafile /tmp/test.lua" +q'`

------
https://chatgpt.com/codex/tasks/task_e_6889c52253dc832da4622d503f0a3cf8