### PR TITLE
Use plenary for async openai job

### DIFF
--- a/lua/delphi/init.lua
+++ b/lua/delphi/init.lua
@@ -124,7 +124,10 @@ local function setup_chat_cmd(config)
 			vim.notify("Coudln't find model " .. tostring(default_model), vim.log.levels.ERROR)
 			return
 		end
-		openai.chat(model, {
+		if vim.b.delphi_chat_job and not vim.b.delphi_chat_job.is_closing then
+			vim.b.delphi_chat_job:shutdown()
+		end
+		vim.b.delphi_chat_job = openai.chat(model, {
 			stream = true,
 			messages = new_messages,
 		}, {
@@ -186,7 +189,10 @@ local function setup_refactor_cmd(config)
 				return
 			end
 
-			openai.chat(model, {
+			if vim.b.delphi_refactor_job and not vim.b.delphi_refactor_job.is_closing then
+				vim.b.delphi_refactor_job:shutdown()
+			end
+			vim.b.delphi_refactor_job = openai.chat(model, {
 				stream = true,
 				messages = {
 					{ role = "system", content = M.opts.refactor.system_prompt },

--- a/lua/delphi/openai.lua
+++ b/lua/delphi/openai.lua
@@ -12,6 +12,8 @@
 --       on_error   = vim.notify,
 --   })
 
+local Job = require("plenary.job")
+
 local M = {}
 
 --- Internal: build curl header list
@@ -30,88 +32,102 @@ end
 ---@param model Model
 ---@param body table
 ---@param cb   {on_chunk: function, on_complete: function, on_error: function}
----@return vim.SystemObj?
+---@return Job
 function M.chat(model, body, cb)
 	body.model = model.model_name
+	cb = cb or {}
 	local payload = vim.json.encode(body)
 
-	local cmd = {
-		"curl",
+	local args = {
 		"-sS",
 		"--no-buffer",
+		"--fail-with-body",
 		"-X",
 		"POST",
 		model.base_url .. "/chat/completions",
 	}
-	vim.list_extend(cmd, build_headers(model:get_api_key()))
-	table.insert(cmd, "-d")
-	table.insert(cmd, payload)
+	vim.list_extend(args, build_headers(model:get_api_key()))
+	table.insert(args, "-d")
+	table.insert(args, payload)
 
 	local stdout_acc, stderr_acc = {}, {}
 
-	--- Parse lines from streaming SSE
-	local function handle_stream(data)
-		if not data then
+	local function handle_stream(chunk)
+		if not chunk then
 			return
 		end
-		for line in data:gmatch("[^\r\n]+") do
+		for line in chunk:gmatch("[^\r\n]+") do
 			if not vim.startswith(line, "data:") then
 				goto continue
 			end
-			local chunk = vim.trim(line:sub(6))
-			if chunk == "[DONE]" then
+			local payload_line = vim.trim(line:sub(6))
+			if payload_line == "[DONE]" then
 				if cb.on_chunk then
-					vim.schedule(function()
-						cb.on_chunk(nil, true)
-					end)
+					cb.on_chunk(nil, true)
 				end
 			else
-				local ok, decoded = pcall(vim.json.decode, chunk, {
+				local ok, decoded = pcall(vim.json.decode, payload_line, {
 					luanil = { object = true, array = true },
 				})
-				if ok and decoded and cb.on_chunk then
-					vim.schedule(function()
+				if ok and decoded then
+					if decoded.error then
+						if cb.on_error then
+							cb.on_error(
+								string.format(
+									"OpenAI %s: %s",
+									tostring(decoded.error.code or ""),
+									decoded.error.message or ""
+								)
+							)
+						end
+					elseif cb.on_chunk then
 						cb.on_chunk(decoded)
-					end)
+					end
+				else
+					table.insert(stderr_acc, payload_line)
 				end
 			end
 			::continue::
 		end
 	end
 
-	local function handle_full_exit(code)
+	local function finalize(code)
+		local stderr = table.concat(stderr_acc, "")
 		if code ~= 0 then
 			if cb.on_error then
-				vim.schedule(function()
-					cb.on_error(table.concat(stderr_acc, ""))
-				end)
+				cb.on_error(stderr ~= "" and stderr or string.format("curl exited with code %d", code))
 			end
 			return
 		end
-		local raw = table.concat(stdout_acc, "")
-		local ok, decoded = pcall(vim.json.decode, raw, {
-			luanil = { object = true, array = true },
-		})
-		if not ok then
-			if cb.on_error then
-				vim.schedule(function()
-					cb.on_error("[openai.lua] JSON decode failed")
-				end)
+		if not body.stream then
+			local raw = table.concat(stdout_acc, "")
+			local ok, decoded = pcall(vim.json.decode, raw, {
+				luanil = { object = true, array = true },
+			})
+			if not ok or not decoded then
+				if cb.on_error then
+					cb.on_error("openai: invalid JSON")
+				end
+				return
 			end
-			return
-		end
-		if cb.on_complete then
-			vim.schedule(function()
+			if decoded.error then
+				if cb.on_error then
+					cb.on_error(
+						string.format("OpenAI %s: %s", tostring(decoded.error.code or ""), decoded.error.message or "")
+					)
+				end
+				return
+			end
+			if cb.on_complete then
 				cb.on_complete(decoded)
-			end)
+			end
 		end
 	end
 
-	-- Spawn curl via libuv (non-blocking)
-	local handle
-	handle = vim.system(cmd, {
-		text = true,
-		stdout = function(_, data)
+	local job = Job:new({
+		command = "curl",
+		args = args,
+		on_stdout = vim.schedule_wrap(function(_, data)
 			if body.stream then
 				handle_stream(data)
 			else
@@ -119,26 +135,19 @@ function M.chat(model, body, cb)
 					stdout_acc[#stdout_acc + 1] = data
 				end
 			end
-		end,
-		stderr = function(_, data)
+		end),
+		on_stderr = vim.schedule_wrap(function(_, data)
 			if data then
 				stderr_acc[#stderr_acc + 1] = data
 			end
-		end,
-		exit_cb = function(_, code)
-			if body.stream then
-				if code ~= 0 and cb.on_error then
-					vim.schedule(function()
-						cb.on_error(table.concat(stderr_acc, ""))
-					end)
-				end
-			else
-				handle_full_exit(code)
-			end
-		end,
+		end),
+		on_exit = vim.schedule_wrap(function(_, code)
+			finalize(code)
+		end),
 	})
 
-	return handle
+	job:start()
+	return job
 end
 
 return M


### PR DESCRIPTION
## Summary
- use `plenary.job` for async `curl` execution
- surface API and transport errors via callbacks
- track running jobs so new requests cancel old ones

## Testing
- `stylua lua/delphi/init.lua lua/delphi/openai.lua`


------
https://chatgpt.com/codex/tasks/task_e_688af4d4b25c832db115eacacd6b9dc3