### PR TITLE
Support new refactor tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ These are the schema:
 ---@field models table<string, Model>
 ---@field allow_env_var_config boolean
 ---@field chat { system_prompt: string, default_model: string?, headers: { system: string, user: string, assistant: string } }
----@field refactor { system_prompt: string, default_model: string?, prompt_template: string, accept_keymap: string, reject_keymap: string }
+---@field rewrite { system_prompt: string, default_model: string?, prompt_template: string, accept_keymap: string, reject_keymap: string }
 ```
 
 These are the default opts:
@@ -35,7 +35,7 @@ opts = {
 			assistant = "Assistant:",
 		},
 	},
-	refactor = {
+	rewrite = {
 		default_model = nil,
 		system_prompt = [[
 You are an expert refactoring assistant. Return ONLY the rewritten code in one fenced block:

--- a/lua/delphi/cmp_source.lua
+++ b/lua/delphi/cmp_source.lua
@@ -1,25 +1,25 @@
-local cmp = require('cmp')
+local cmp = require("cmp")
 local source = {}
 
 function source:is_available()
-    return vim.b.is_delphi_chat == true
+	return vim.b.is_delphi_chat == true
 end
 
 function source:complete(params, callback)
-    local line = params.context.cursor_before_line
-    local col = params.context.cursor.col
-    local prefix = line:sub(1, col)
-    local at = prefix:match('@(%S*)$')
-    if not at then
-        return callback()
-    end
-    local pat = at .. '*'
-    local paths = vim.fn.glob(pat, true, true)
-    local items = {}
-    for _, p in ipairs(paths) do
-        table.insert(items, { label = '@' .. p, insertText = '@' .. p })
-    end
-    callback({ items = items, isIncomplete = false })
+	local line = params.context.cursor_before_line
+	local col = params.context.cursor.col
+	local prefix = line:sub(1, col)
+	local at = prefix:match("@(%S*)$")
+	if not at then
+		return callback()
+	end
+	local pat = at .. "*"
+	local paths = vim.fn.glob(pat, true, true)
+	local items = {}
+	for _, p in ipairs(paths) do
+		table.insert(items, { label = "@" .. p, insertText = "@" .. p })
+	end
+	callback({ items = items, isIncomplete = false })
 end
 
 return source

--- a/lua/delphi/extractor.lua
+++ b/lua/delphi/extractor.lua
@@ -1,106 +1,119 @@
---- Grab markdown code block from streaming responses in O(n) time
---- with this state machine
+-- Extract code enclosed in <delphi:refactored_code> tags from a streaming
+-- response. Works in O(n) overall and produces incremental output.
 
-local function idle(code, c)
-	if c == "`" then
-		return code, "TICK_1"
-	end
-	return code, "IDLE"
-end
+local START_TAG = "<delphi:refactored_code>"
+local END_TAG = "</delphi:refactored_code>"
 
-local function tick_1(code, c)
-	if c == "`" then
-		return code, "TICK_2"
-	end
-	return code, "IDLE"
-end
-
-local function tick_2(code, c)
-	if c == "`" then
-		return code, "TICK_3"
-	end
-	return code, "IDLE"
-end
-
-local function tick_3(code, c)
-	-- allow arbitrary text after ``` until the next newline
-	if c == "\n" then
-		return code, "RECORDING"
-	end
-	return code, "TICK_3"
-end
-
-local function recording(code, c)
-	if c == "`" then
-		return code, "END_TICK_1"
-	end
-	return code .. c, "RECORDING"
-end
-
-local function end_tick_1(code, c)
-	if c == "`" then
-		return code, "END_TICK_2"
-	end
-	-- not actually a code fence, flush the pending tick
-	return code .. "`" .. c, "RECORDING"
-end
-
-local function end_tick_2(code, c)
-	if c == "`" then
-		return code, "DONE"
-	end
-	-- not actually a code fence, flush the pending ticks
-	return code .. "``" .. c, "RECORDING"
-end
-
-local function end_tick_3(code, c)
-	if c == "`" then
-		return code, "DONE"
-	end
-	return code .. c, "RECORDING"
-end
-
-local function done(code, _)
-	return code, "DONE"
-end
-
-local state_to_fn = {
-	IDLE = idle,
-	TICK_1 = tick_1,
-	TICK_2 = tick_2,
-	TICK_3 = tick_3,
-	RECORDING = recording,
-	END_TICK_1 = end_tick_1,
-	END_TICK_2 = end_tick_2,
-	END_TICK_3 = end_tick_3,
-	DONE = done,
-}
-
+---@class Extractor
+---@field state 'SEARCH_START'|'AFTER_START'|'OPEN_FENCE'|'SKIP_LANG'|'RECORDING'|'MAYBE_END'|'DONE'
+---@field start_idx integer
+---@field end_idx integer
+---@field tick_count integer
+---@field pending string
+---@field finished boolean
+---@field code string
 local Extractor = {}
 Extractor.__index = Extractor
 
 function Extractor.new()
-	return setmetatable({ state = "IDLE", code = "" }, Extractor)
+	---@type Extractor
+	local e = {
+		state = "SEARCH_START",
+		start_idx = 0,
+		end_idx = 0,
+		tick_count = 0,
+		pending = "",
+		finished = false,
+		code = "",
+	}
+	return setmetatable(e, Extractor)
 end
 
+---@param delta string
+---@return string
 function Extractor:update(delta)
-	local new_code = ""
-	for i = 1, #delta do
-		if self.state == "DONE" then
-			break
-		end
-		new_code, self.state = state_to_fn[self.state](new_code, delta:sub(i, i))
+	if self.finished or #delta == 0 then
+		return ""
 	end
-	self.code = self.code .. new_code
-	return new_code
+	local out = ""
+	for i = 1, #delta do
+		local ch = delta:sub(i, i)
+
+		if self.state == "SEARCH_START" then
+			if ch == START_TAG:sub(self.start_idx + 1, self.start_idx + 1) then
+				self.start_idx = self.start_idx + 1
+				if self.start_idx == #START_TAG then
+					self.state = "AFTER_START"
+					self.start_idx = 0
+				end
+			else
+				self.start_idx = (ch == START_TAG:sub(1, 1)) and 1 or 0
+			end
+		elseif self.state == "AFTER_START" then
+			if ch == "\n" then
+				self.state = "OPEN_FENCE"
+				self.tick_count = 0
+			elseif ch == "`" then
+				self.state = "OPEN_FENCE"
+				self.tick_count = 1
+			else
+				out = out .. ch
+				self.code = self.code .. ch
+				self.state = "RECORDING"
+			end
+		elseif self.state == "OPEN_FENCE" then
+			if self.tick_count < 3 then
+				if ch == "`" then
+					self.tick_count = self.tick_count + 1
+					if self.tick_count == 3 then
+						-- wait for optional language + newline
+						self.state = "SKIP_LANG"
+					end
+				else
+					-- not actually a fence
+					out = out .. string.rep("`", self.tick_count) .. ch
+					self.code = self.code .. string.rep("`", self.tick_count) .. ch
+					self.state = "RECORDING"
+					self.tick_count = 0
+				end
+			end
+		elseif self.state == "SKIP_LANG" then
+			if ch == "\n" then
+				self.state = "RECORDING"
+			end
+		elseif self.state == "RECORDING" then
+			if ch == "<" then
+				self.state = "MAYBE_END"
+				self.end_idx = 1
+				self.pending = "<"
+			else
+				out = out .. ch
+				self.code = self.code .. ch
+			end
+		elseif self.state == "MAYBE_END" then
+			if ch == END_TAG:sub(self.end_idx + 1, self.end_idx + 1) then
+				self.end_idx = self.end_idx + 1
+				self.pending = self.pending .. ch
+				if self.end_idx == #END_TAG then
+					self.code = self.code:gsub("```%s*$", "")
+					self.state = "DONE"
+					self.finished = true
+					break
+				end
+			else
+				out = out .. self.pending .. ch
+				self.code = self.code .. self.pending .. ch
+				self.pending = ""
+				self.end_idx = 0
+				self.state = "RECORDING"
+			end
+		end
+	end
+	return out
 end
 
+---@return string
 function Extractor:get_code()
-	if self.state == "END_TICK_1" then
-		return self.code .. "`"
-	elseif self.state == "END_TICK_2" then
-		return self.code .. "``"
-	end
 	return self.code
 end
 

--- a/lua/delphi/init.lua
+++ b/lua/delphi/init.lua
@@ -21,20 +21,20 @@ local default_opts = {
 	rewrite = {
 		default_model = nil,
 		system_prompt = [[
-You are an expert refactoring assistant. Respond with the rewritten code enclosed in <delphi:refactored_code> tags:
+You are an expert refactoring assistant. You ALWAYS respond with the rewritten code or text enclosed in <delphi:refactored_code> tags:
 <delphi:refactored_code>
 ...
 </delphi:refactored_code>]],
 		prompt_template = [[
 Full file for context:
-```
+<delphi:current_file>
 {{file_text}}
-```
+</delphi:current_file>
 
 Selected lines ({{selection_start_lnum}}:{{selection_end_lnum}}):
-```
+<delphi:selected_lines>
 {{selected_text}}
-```
+</delphi:selected_lines>
 
 Instruction: {{user_instructions}}. Return ONLY the refactored code inside <delphi:refactored_code> tags. Preserve formatting unless told otherwise. Try to keep the diff minimal while following the instructions exactly.]],
 		accept_keymap = "<leader>a",

--- a/lua/delphi/init.lua
+++ b/lua/delphi/init.lua
@@ -21,10 +21,10 @@ local default_opts = {
 	rewrite = {
 		default_model = nil,
 		system_prompt = [[
-You are an expert refactoring assistant. Return ONLY the rewritten code in one fenced block:
-```
+You are an expert refactoring assistant. Respond with the rewritten code enclosed in <delphi:refactored_code> tags:
+<delphi:refactored_code>
 ...
-```.]],
+</delphi:refactored_code>]],
 		prompt_template = [[
 Full file for context:
 ```
@@ -36,7 +36,7 @@ Selected lines ({{selection_start_lnum}}:{{selection_end_lnum}}):
 {{selected_text}}
 ```
 
-Instruction: {{user_instructions}}. Return ONLY the refactored code within a code block. Preserve formatting unless told otherwise. Try to keep the diff minimal while following the instructions exactly.]],
+Instruction: {{user_instructions}}. Return ONLY the refactored code inside <delphi:refactored_code> tags. Preserve formatting unless told otherwise. Try to keep the diff minimal while following the instructions exactly.]],
 		accept_keymap = "<leader>a",
 		reject_keymap = "<leader>r",
 	},

--- a/lua/delphi/openai_mock.lua
+++ b/lua/delphi/openai_mock.lua
@@ -10,7 +10,8 @@ function M.chat(body, cb)
 	cb = cb or {}
 	local i, timer = 1, uv.new_timer()
 	local new_text = [[
-```
+<delphi:refactored_code>
+```python
 def fib(n: int, cache: dict[int, int] = defaultdict(int)):
     if n <= 1:
         return 1
@@ -18,6 +19,7 @@ def fib(n: int, cache: dict[int, int] = defaultdict(int)):
     cache[n] = ret
     return ret
 ```
+</delphi:refactored_code>
 ]]
 
 	local function tick()


### PR DESCRIPTION
## Summary
- update rewrite prompts to instruct LLM to wrap code with `<delphi:refactored_code>` tags
- add tag-based streaming extractor
- adjust mock OpenAI responses for the new tag style
- simplify extractor state machine for constant-time updates
- closes #7 
## Testing
- `nix develop -c stylua lua/delphi/extractor.lua lua/delphi/init.lua lua/delphi/openai_mock.lua`
- ❌ `nvtest --headless /tmp/test.lua` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688af83df554832d8d896e94d809b496