### PR TITLE
Improve Chat buffer reuse and add default keymaps

### DIFF
--- a/lua/delphi/primitives.lua
+++ b/lua/delphi/primitives.lua
@@ -248,6 +248,35 @@ function P.open_new_chat_buffer(system_prompt, model_name, temperature)
 	return buf
 end
 
+---Find the first loaded delphi chat buffer
+---@return integer|nil buf
+function P.find_chat_buffer()
+	for _, b in ipairs(vim.api.nvim_list_bufs()) do
+		if vim.api.nvim_buf_is_loaded(b) and vim.b[b].is_delphi_chat then
+			return b
+		end
+	end
+	return nil
+end
+
+---Create a new chat in a horizontal split
+---@param system_prompt string
+---@param model_name string
+---@param temperature number
+function P.split_new_chat(system_prompt, model_name, temperature)
+	vim.cmd("split")
+	return P.open_new_chat_buffer(system_prompt, model_name, temperature)
+end
+
+---Create a new chat in a vertical split
+---@param system_prompt string
+---@param model_name string
+---@param temperature number
+function P.vsplit_new_chat(system_prompt, model_name, temperature)
+	vim.cmd("vsplit")
+	return P.open_new_chat_buffer(system_prompt, model_name, temperature)
+end
+
 -- Persistent chat helpers ----------------------------------------------------
 
 ---Return directory for chat transcripts (created on demand)


### PR DESCRIPTION
## Summary
- reuse existing chat buffer when running `:Chat`
- support `:Chat new`, `:Chat split`, and `:Chat vsplit`
- provide helper functions for chat splits and buffer search
- add configurable default keymaps for chat and rewrite features

## Testing
- `nix develop -c stylua lua/delphi/init.lua lua/delphi/primitives.lua`

------
https://chatgpt.com/codex/tasks/task_e_688b00c91c98832d8e11240749349b3e