### PR TITLE
Add chat buffer reuse and default keymaps

### DIFF
--- a/lua/delphi/cmp_source.lua
+++ b/lua/delphi/cmp_source.lua
@@ -1,25 +1,25 @@
-local cmp = require('cmp')
+local cmp = require("cmp")
 local source = {}
 
 function source:is_available()
-    return vim.b.is_delphi_chat == true
+	return vim.b.is_delphi_chat == true
 end
 
 function source:complete(params, callback)
-    local line = params.context.cursor_before_line
-    local col = params.context.cursor.col
-    local prefix = line:sub(1, col)
-    local at = prefix:match('@(%S*)$')
-    if not at then
-        return callback()
-    end
-    local pat = at .. '*'
-    local paths = vim.fn.glob(pat, true, true)
-    local items = {}
-    for _, p in ipairs(paths) do
-        table.insert(items, { label = '@' .. p, insertText = '@' .. p })
-    end
-    callback({ items = items, isIncomplete = false })
+	local line = params.context.cursor_before_line
+	local col = params.context.cursor.col
+	local prefix = line:sub(1, col)
+	local at = prefix:match("@(%S*)$")
+	if not at then
+		return callback()
+	end
+	local pat = at .. "*"
+	local paths = vim.fn.glob(pat, true, true)
+	local items = {}
+	for _, p in ipairs(paths) do
+		table.insert(items, { label = "@" .. p, insertText = "@" .. p })
+	end
+	callback({ items = items, isIncomplete = false })
 end
 
 return source

--- a/lua/delphi/init.lua
+++ b/lua/delphi/init.lua
@@ -298,9 +298,7 @@ function M.setup(opts)
 	if ok then
 		cmp.register_source("delphi_path", require("delphi.cmp_source"))
 	end
-	vim.keymap.set("x", M.opts.rewrite.global_rewrite_keymap, function()
-		vim.cmd([[Rewrite]])
-	end)
+	vim.keymap.set("x", M.opts.rewrite.global_rewrite_keymap, ":Rewrite<cr>", { noremap = true, silent = true })
 end
 
 return M

--- a/lua/delphi/init.lua
+++ b/lua/delphi/init.lua
@@ -91,10 +91,10 @@ local function setup_chat_cmd(config)
 			return
 		end
 
-		local orientation
-		if args[1] == "split" then
+		local orientation = nil
+		if args[1] == "split" or args[1] == "sp" then
 			orientation = "horizontal"
-		elseif args[1] == "vsplit" then
+		elseif args[1] == "vsplit" or args[1] == "vsp" then
 			orientation = "vertical"
 		end
 
@@ -121,6 +121,9 @@ local function setup_chat_cmd(config)
 		local buf = vim.api.nvim_get_current_buf()
 		if args[1] == "new" or orientation then
 			create_chat()
+			return
+		elseif args[1] ~= nil then
+			vim.notify("delphi: Invalid Chat subcommand " .. tostring(args[1]), vim.log.levels.ERROR)
 			return
 		end
 

--- a/lua/delphi/init.lua
+++ b/lua/delphi/init.lua
@@ -6,6 +6,7 @@ local P = require("delphi.primitives")
 ---@field allow_env_var_config boolean
 ---@field chat { system_prompt: string, default_model: string?, headers: { system: string, user: string, assistant: string } }
 ---@field rewrite { system_prompt: string, default_model: string?, prompt_template: string, accept_keymap: string, reject_keymap: string }
+---@field keys { chat: table, global: table }
 local default_opts = {
 	models = {},
 	allow_env_var_config = false,
@@ -18,8 +19,8 @@ local default_opts = {
 			assistant = "Assistant:",
 		},
 	},
-	rewrite = {
-		default_model = nil,
+        rewrite = {
+                default_model = nil,
 		system_prompt = [[
 You are an expert refactoring assistant. Return ONLY the rewritten code in one fenced block:
 ```
@@ -38,10 +39,36 @@ Selected lines ({{selection_start_lnum}}:{{selection_end_lnum}}):
 
 Instruction: {{user_instructions}}. Return ONLY the refactored code within a code block. Preserve formatting unless told otherwise. Try to keep the diff minimal while following the instructions exactly.]],
 		accept_keymap = "<leader>a",
-		reject_keymap = "<leader>r",
-	},
+                reject_keymap = "<leader>r",
+        },
+        keys = {
+                global = {
+                        x = { ["<leader>r"] = { cmd = "Rewrite", desc = "rewrite selection" } },
+                },
+                chat = {
+                        n = { ["<leader><CR>"] = { cmd = "Chat", desc = "send chat" } },
+                        i = { ["<leader><CR>"] = { cmd = "Chat", desc = "send chat" } },
+                },
+        },
 }
 local M = { opts = default_opts }
+
+local function apply_keymaps(maps, buf)
+        local ok, Keys = pcall(require, "lazy.core.handler")
+        Keys = ok and Keys.handlers.keys or nil
+        for mode, ms in pairs(maps) do
+                for lhs, spec in pairs(ms) do
+                        if spec and (not Keys or not Keys.active[Keys.parse({ lhs, mode = mode })]) then
+                                local opts = { desc = spec.desc, silent = true, buffer = buf }
+                                vim.keymap.set(mode, lhs, spec.cmd or spec, opts)
+                        end
+                end
+        end
+end
+
+function M.apply_chat_keymaps(buf)
+        apply_keymaps(M.opts.keys.chat, buf)
+end
 
 local function get_delta(chunk)
 	if not chunk or not chunk.choices then
@@ -56,15 +83,15 @@ local function get_delta(chunk)
 end
 
 local function setup_chat_cmd(config)
-	vim.api.nvim_create_user_command("Chat", function(opts)
-		local args = opts.fargs
+        vim.api.nvim_create_user_command("Chat", function(opts)
+                local args = opts.fargs
 
-		if args[1] == "list" then
-			for i, item in ipairs(P.list_chats()) do
-				print(string.format("%d. %s", i - 1, item.preview))
-			end
-			return
-		elseif args[1] == "go" and args[2] then
+                if args[1] == "list" then
+                        for i, item in ipairs(P.list_chats()) do
+                                print(string.format("%d. %s", i - 1, item.preview))
+                        end
+                        return
+                elseif args[1] == "go" and args[2] then
 			local idx = tonumber(args[2])
 			if not idx then
 				return vim.notify("Invalid chat number")
@@ -73,26 +100,56 @@ local function setup_chat_cmd(config)
 			if not entry then
 				return vim.notify("Chat not found")
 			end
-			P.open_chat_file(entry.path)
-			return
-		end
+                        local b = P.open_chat_file(entry.path)
+                        M.apply_chat_keymaps(b)
+                        return
+                end
 
-		local buf = vim.api.nvim_get_current_buf()
-		if not vim.b.is_delphi_chat then
-			local default_model
-			if M.opts.allow_env_var_config and os.getenv("DELPHI_DEFAULT_CHAT_MODEL") then
-				default_model = os.getenv("DELPHI_DEFAULT_CHAT_MODEL")
-			else
-				default_model = config.default_model
-			end
-			local model_cfg = M.opts.models[default_model] or {}
-			buf = P.open_new_chat_buffer(config.system_prompt, default_model, model_cfg.temperature)
-			vim.b.is_delphi_chat = true
-			vim.b.delphi_chat_path = P.next_chat_path()
-			vim.b.delphi_meta_path = vim.b.delphi_chat_path:gsub("%.md$", "_meta.json")
-			P.save_chat(buf)
-			return
-		end
+                local orientation
+                if args[1] == "split" then
+                        orientation = "horizontal"
+                elseif args[1] == "vsplit" then
+                        orientation = "vertical"
+                end
+
+                local function create_chat()
+                        if orientation then
+                                P.new_split(orientation)
+                        end
+                        local default_model
+                        if M.opts.allow_env_var_config and os.getenv("DELPHI_DEFAULT_CHAT_MODEL") then
+                                default_model = os.getenv("DELPHI_DEFAULT_CHAT_MODEL")
+                        else
+                                default_model = config.default_model
+                        end
+                        local model_cfg = M.opts.models[default_model] or {}
+                        local b = P.open_new_chat_buffer(config.system_prompt, default_model, model_cfg.temperature)
+                        vim.b.is_delphi_chat = true
+                        vim.b.delphi_chat_path = P.next_chat_path()
+                        vim.b.delphi_meta_path = vim.b.delphi_chat_path:gsub("%.md$", "_meta.json")
+                        P.save_chat(b)
+                        M.apply_chat_keymaps(b)
+                        return b
+                end
+
+                local buf = vim.api.nvim_get_current_buf()
+                if args[1] == "new" or orientation then
+                        create_chat()
+                        return
+                end
+
+                if not vim.b.is_delphi_chat then
+                        local existing = P.find_chat_buffer()
+                        if existing then
+                                P.set_current_buf(existing)
+                                M.apply_chat_keymaps(existing)
+                                P.set_cursor_to_user(existing)
+                                return
+                        else
+                                create_chat()
+                                return
+                        end
+                end
 
 		local transcript = P.read_buf(buf)
 		local messages = P.to_messages(transcript)
@@ -240,16 +297,33 @@ end
 ---Setup delphi
 ---@param opts Config
 function M.setup(opts)
-	local models = opts.models
-	local Model = require("delphi.model").Model
-	for k, v in pairs(models) do
-		models[k] = Model.new(v)
-	end
+        local models = opts.models or {}
+        local Model = require("delphi.model").Model
+        for k, v in pairs(models) do
+                models[k] = Model.new(v)
+        end
 
-	M.opts = vim.tbl_deep_extend("force", M.opts, opts or {})
-	P.set_headers(M.opts.chat.headers)
-	setup_chat_cmd(M.opts.chat)
-	setup_rewrite_cmd(M.opts.rewrite)
+        local keys = opts.keys or {}
+        keys.global = vim.tbl_deep_extend("force", default_opts.keys.global, keys.global or {})
+        keys.chat = vim.tbl_deep_extend("force", default_opts.keys.chat, keys.chat or {})
+
+        opts.keys = nil
+
+        M.opts = vim.tbl_deep_extend("force", M.opts, opts or {})
+        M.opts.keys = keys
+
+        P.set_headers(M.opts.chat.headers)
+        setup_chat_cmd(M.opts.chat)
+        setup_rewrite_cmd(M.opts.rewrite)
+
+        apply_keymaps(M.opts.keys.global)
+        vim.api.nvim_create_autocmd("BufEnter", {
+                callback = function(ev)
+                        if vim.b[ev.buf].is_delphi_chat then
+                                M.apply_chat_keymaps(ev.buf)
+                        end
+                end,
+        })
 
 	local ok, cmp = pcall(require, "cmp")
 	if ok then

--- a/lua/delphi/primitives.lua
+++ b/lua/delphi/primitives.lua
@@ -290,8 +290,37 @@ function P.open_chat_file(path)
 	vim.b.is_delphi_chat = true
 	vim.b.delphi_chat_path = path
 	vim.b.delphi_meta_path = path:gsub("%.md$", "_meta.json")
-	P.set_cursor_to_user(buf)
-	return buf
+        P.set_cursor_to_user(buf)
+        return buf
+end
+
+---Return the first loaded chat buffer, if any
+---@return integer|nil buf
+function P.find_chat_buffer()
+    for _, b in ipairs(vim.api.nvim_list_bufs()) do
+        if vim.api.nvim_buf_is_loaded(b) and vim.b[b].is_delphi_chat then
+            return b
+        end
+    end
+    return nil
+end
+
+---Create a new window split
+---@param dir 'horizontal'|'vertical'
+---@return integer win
+function P.new_split(dir)
+    if dir == 'vertical' then
+        vim.api.nvim_cmd({ cmd = 'vsplit' }, {})
+    else
+        vim.api.nvim_cmd({ cmd = 'split' }, {})
+    end
+    return vim.api.nvim_get_current_win()
+end
+
+---Focus the given buffer in the current window
+---@param buf integer
+function P.set_current_buf(buf)
+    vim.api.nvim_set_current_buf(buf)
 end
 
 ---Save a chat buffer to its associated path

--- a/lua/delphi/primitives.lua
+++ b/lua/delphi/primitives.lua
@@ -290,37 +290,37 @@ function P.open_chat_file(path)
 	vim.b.is_delphi_chat = true
 	vim.b.delphi_chat_path = path
 	vim.b.delphi_meta_path = path:gsub("%.md$", "_meta.json")
-        P.set_cursor_to_user(buf)
-        return buf
+	P.set_cursor_to_user(buf)
+	return buf
 end
 
 ---Return the first loaded chat buffer, if any
 ---@return integer|nil buf
 function P.find_chat_buffer()
-    for _, b in ipairs(vim.api.nvim_list_bufs()) do
-        if vim.api.nvim_buf_is_loaded(b) and vim.b[b].is_delphi_chat then
-            return b
-        end
-    end
-    return nil
+	for _, b in ipairs(vim.api.nvim_list_bufs()) do
+		if vim.api.nvim_buf_is_loaded(b) and vim.b[b].is_delphi_chat then
+			return b
+		end
+	end
+	return nil
 end
 
 ---Create a new window split
 ---@param dir 'horizontal'|'vertical'
 ---@return integer win
 function P.new_split(dir)
-    if dir == 'vertical' then
-        vim.api.nvim_cmd({ cmd = 'vsplit' }, {})
-    else
-        vim.api.nvim_cmd({ cmd = 'split' }, {})
-    end
-    return vim.api.nvim_get_current_win()
+	if dir == "vertical" then
+		vim.api.nvim_cmd({ cmd = "vsplit" }, {})
+	else
+		vim.api.nvim_cmd({ cmd = "split" }, {})
+	end
+	return vim.api.nvim_get_current_win()
 end
 
 ---Focus the given buffer in the current window
 ---@param buf integer
 function P.set_current_buf(buf)
-    vim.api.nvim_set_current_buf(buf)
+	vim.api.nvim_set_current_buf(buf)
 end
 
 ---Save a chat buffer to its associated path


### PR DESCRIPTION
## Summary
- reuse an existing chat buffer when running `:Chat`
- support `:Chat new|split|vsplit`
- provide configurable default keymaps for chat and rewrite
- expose primitives for finding chat buffers and splitting windows

## Testing
- `nix develop -c stylua lua/delphi/primitives.lua lua/delphi/init.lua` *(failed: environment build interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_688b00c91c98832d8e11240749349b3e