### PR TITLE
feat: search full chat contents

### DIFF
--- a/lua/delphi/primitives.lua
+++ b/lua/delphi/primitives.lua
@@ -337,7 +337,7 @@ function P.save_chat(buf, path)
 end
 
 ---List available chats
----@return { path:string, preview:string }[]
+---@return { path:string, preview:string, text:string }[]
 function P.list_chats()
 	local dir = P.chat_data_dir()
 	local files = vim.fn.readdir(dir)
@@ -366,7 +366,7 @@ function P.list_chats()
 				if #preview > 40 then
 					preview = preview:sub(1, 37) .. "..."
 				end
-				table.insert(res, { path = p, preview = preview })
+				table.insert(res, { path = p, preview = preview, text = text })
 			end
 		end
 	end

--- a/lua/telescope/_extensions/delphi.lua
+++ b/lua/telescope/_extensions/delphi.lua
@@ -22,7 +22,7 @@ function M.chats(opts)
 					return {
 						value = item.path,
 						display = item.preview,
-						ordinal = item.preview,
+						ordinal = item.text,
 					}
 				end,
 			}),


### PR DESCRIPTION
## Summary
- allow Telescope chat picker to search across full chat contents
- track full text in `list_chats`

## Testing
- `nix develop -c stylua --check lua/delphi/primitives.lua lua/telescope/_extensions/delphi.lua`
- `nix develop -c bash -lc 'nvim --headless --clean -u "$NVIM_TEST_HOME/init.lua" -c "lua local P=require(\"delphi.primitives\"); local dir=P.chat_data_dir(); vim.fn.mkdir(dir,\"p\"); local path=dir..\"/chat_1.md\"; vim.fn.writefile({\"User:\",\"hello\",\"Assistant:\",\"hi\"}, path); print(vim.inspect(P.list_chats()))" -c qa!'`


------
https://chatgpt.com/codex/tasks/task_e_6892f7b5d3b8832da653a5d74cf47b7d