### PR TITLE
feat: add default telescope chat search keymap

### DIFF
--- a/lua/delphi/primitives.lua
+++ b/lua/delphi/primitives.lua
@@ -20,6 +20,15 @@ function P.set_headers(hdrs)
 	end
 end
 
+---Set a keymap
+---@param modes string|string[]
+---@param lhs string
+---@param rhs string|fun()
+---@param opts table|nil
+function P.set_keymap(modes, lhs, rhs, opts)
+	vim.keymap.set(modes, lhs, rhs, opts)
+end
+
 ---Fill in a template string
 ---@param str string
 ---@param env table


### PR DESCRIPTION
## Summary
- add configurable default keymap to live search chat transcripts via Telescope
- expose a primitive wrapper for setting keymaps

## Testing
- `nix develop -c stylua lua/delphi/init.lua lua/delphi/primitives.lua`
- `nix develop` then `nvtest --headless -c "lua require('delphi').setup({})" -c "lua for _,m in ipairs(vim.api.nvim_get_keymap('n')) do if m.desc=='Search chats' then print('mapped') end end" -c qa`


------
https://chatgpt.com/codex/tasks/task_e_6892f71c5fac832da8ac6d2271c8f06b