### PR TITLE
feat: store chat as structured metadata

### DIFF
--- a/lua/delphi/init.lua
+++ b/lua/delphi/init.lua
@@ -157,7 +157,7 @@ local function setup_chat_cmd(config)
 		end
 
 		local new_meta, new_messages = P.resolve_tags(meta, messages)
-		new_meta.stored_lines = cur_lines
+		new_meta.chat = new_messages
 
 		P.write_chat_meta(vim.b.delphi_chat_path, new_meta)
 


### PR DESCRIPTION
## Summary
- replace `stored_lines` metadata with `chat` array of role/content messages
- add `messages_to_lines` helper and use structured chat for validation and undo

## Testing
- `nix develop -c stylua lua/delphi/primitives.lua lua/delphi/init.lua`
- `nix develop -c nvim --headless -u NONE -c "set rtp+=." -c "luafile /tmp/test.lua" -c quit`


------
https://chatgpt.com/codex/tasks/task_e_6892f860a294832d81955bda8d8a2e93