### PR TITLE
fix(chat): make ChatSend mapping global for reliability

### DIFF
--- a/lua/delphi/init.lua
+++ b/lua/delphi/init.lua
@@ -31,10 +31,11 @@ local M = { opts = default_opts }
 ---Set chat send keymap
 ---@param buf integer
 function M.apply_chat_keymaps(buf)
-	local opts = { desc = "Delphi: send message", silent = true, buffer = buf }
-	vim.keymap.set("n", "<Plug>(DelphiChatSend)", function()
-		vim.cmd([[Chat]])
-	end, opts)
+	-- Delegate to primitives to keep all API usage centralized and idempotent.
+	-- This now applies a global <Plug> mapping so user keymaps work regardless
+	-- of how the chat buffer was opened (Telescope, Chat go, etc.).
+	local P = require("delphi.primitives")
+	P.apply_chat_plug_mappings()
 end
 
 local function get_delta(chunk)
@@ -202,6 +203,8 @@ local function setup_chat_cmd(config)
 			end,
 		})
 	end, { nargs = "*" })
+	-- Ensure global <Plug> mapping exists so user mappings always work.
+	require("delphi.primitives").apply_chat_plug_mappings()
 end
 
 local function setup_rewrite_cmd(config)
@@ -284,9 +287,9 @@ local function setup_rewrite_cmd(config)
 			})
 		end)
 	end, { range = true, desc = "LLM-rewrite the current visual selection or insert-at-cursor" })
-    -- Define <Plug> mappings once so users can bind ergonomically
-    require("delphi.primitives").apply_rewrite_plug_mappings()
-    end
+	-- Define <Plug> mappings once so users can bind ergonomically
+	require("delphi.primitives").apply_rewrite_plug_mappings()
+end
 
 ---Setup delphi
 ---@param opts Config

--- a/lua/delphi/primitives.lua
+++ b/lua/delphi/primitives.lua
@@ -20,6 +20,20 @@ function P.set_headers(hdrs)
 	end
 end
 
+---Ensure <Plug>-style mapping for Chat send exists globally.
+---@return nil
+function P.apply_chat_plug_mappings()
+	if vim.g.delphi_chat_plugs_applied then
+		return
+	end
+	vim.g.delphi_chat_plugs_applied = true
+
+	-- Normal mode: send chat (resolves context inside :Chat)
+	vim.keymap.set("n", "<Plug>(DelphiChatSend)", function()
+		vim.cmd([[Chat]])
+	end, { desc = "Delphi: send chat", silent = true })
+end
+
 ---Fill in a template string
 ---@param str string
 ---@param env table


### PR DESCRIPTION
This fixes intermittent missing keymaps when opening chats via Telescope or `:Chat go` by making the `<Plug>(DelphiChatSend)` mapping global and idempotent.

Changes:
- Add `apply_chat_plug_mappings()` in `delphi.primitives` to define global `<Plug>(DelphiChatSend)` once.
- Update `init.lua` to delegate to primitives and ensure mapping is applied during Chat command setup and when opening/creating chats.
- Keeps all Neovim API mapping calls in `primitives.lua` per guidelines.

Testing:
- Open chats via `:Telescope delphi chats` and via `:Chat go <idx>`.
- Trigger your user mapping (e.g., `<leader><cr>` mapped to `<Plug>(DelphiChatSend)`); send should always work.

Notes:
- No README changes; code formatted with stylua.
