### PR TITLE
feat(chat): add scroll_on_send (default true) to scroll last User header to top on send

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Example configuration with lazy.nvim:
   },
   cmd = { "Chat", "Rewrite" },
   opts = {
-    chat = { default_model = "gemini_flash" },
+    chat = { default_model = "gemini_flash", scroll_on_send = true },
     rewrite = { default_model = "gemini_flash" },
     models = {
       gemini_flash = {
@@ -155,7 +155,7 @@ Configuration schema:
 ---@class Config
 ---@field models table<string, Model>
 ---@field allow_env_var_config boolean
----@field chat { system_prompt: string, default_model: string?, headers: { system: string, user: string, assistant: string } }
+---@field chat { system_prompt: string, default_model: string?, headers: { system: string, user: string, assistant: string }, scroll_on_send: boolean }
 ---@field rewrite { default_model: string? }
 ```
 
@@ -173,6 +173,7 @@ opts = {
       user = "User:",
       assistant = "Assistant:",
     },
+    scroll_on_send = true,
   },
   rewrite = {
     default_model = nil,

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
                   cmd = { "Chat", "Rewrite" },
                   opts = {
                     allow_env_var_config = true,
-                    chat = { default_model = "gemini_flash" },
+                    chat = { default_model = "gemini_flash", scroll_on_send = true },
                     rewrite = { default_model = "gemini_flash" },
                     models = {
                       gemini_flash = {

--- a/lua/delphi/init.lua
+++ b/lua/delphi/init.lua
@@ -5,7 +5,7 @@
 ---@class Config
 ---@field models table<string, Model>
 ---@field allow_env_var_config boolean
----@field chat { system_prompt: string, default_model: string?, headers: { system: string, user: string, assistant: string } }
+---@field chat { system_prompt: string, default_model: string?, headers: { system: string, user: string, assistant: string }, scroll_on_send: boolean }
 ---@field rewrite { default_model: string? }
 local default_opts = {
 	models = {},
@@ -18,6 +18,7 @@ local default_opts = {
 			user = "User:",
 			assistant = "Assistant:",
 		},
+		scroll_on_send = true,
 	},
 	rewrite = {
 		default_model = nil,
@@ -144,6 +145,11 @@ local function setup_chat_cmd(config)
 		new_meta.stored_lines = cur_lines
 
 		P.write_chat_meta(vim.b.delphi_chat_path, new_meta)
+
+		-- Optionally scroll so the last User header is at the top
+		if config.scroll_on_send then
+			P.scroll_last_user_to_top(buf)
+		end
 
 		-- Add assistant header and start a right-aligned spinner on that line
 		P.append_line_to_buf(buf, "")


### PR DESCRIPTION
This PR adds a new chat option `chat.scroll_on_send` (default: `true`).

- When enabled, before streaming an Assistant response, the chat view scrolls so the last `User:` header is the top of the window. This maximizes space for the streaming message.
- Added `P.scroll_last_user_to_top(buf)` in `primitives.lua` that adjusts `topline` for all windows showing the chat buffer using `winsaveview()`/`winrestview()`.
- Wired the scroll into the Chat send flow right after writing chat metadata and before inserting the Assistant header.
- Updated README config schema, defaults, example config, and usage docs to include `scroll_on_send`.
- Formatted with stylua.

If desired, set `chat.scroll_on_send = false` to disable.
