### PR TITLE
fix(chat): restrict send mapping to chat buffers only

### DIFF
--- a/lua/delphi/primitives.lua
+++ b/lua/delphi/primitives.lua
@@ -30,6 +30,10 @@ function P.apply_chat_plug_mappings()
 
 	-- Normal mode: send chat (resolves context inside :Chat)
 	vim.keymap.set("n", "<Plug>(DelphiChatSend)", function()
+		local buf = vim.api.nvim_get_current_buf()
+		if not vim.b[buf].is_delphi_chat then
+			return
+		end
 		vim.cmd([[Chat]])
 	end, { desc = "Delphi: send chat", silent = true })
 end


### PR DESCRIPTION
Prevents the Chat send mapping (<Plug>(DelphiChatSend)) from opening a chat when invoked outside an actual chat buffer (e.g., inside the rewrite prompt popup). It now no-ops unless `b:is_delphi_chat` is set in the current buffer.